### PR TITLE
fix: connectToDatabase() can connect to DocumentDB now w/o errors

### DIFF
--- a/backend/src/controllers/mongo.ts
+++ b/backend/src/controllers/mongo.ts
@@ -41,7 +41,7 @@ class MongoClient {
   public async connectToDatabase(): Promise<void> {
     try {
       if (mongoose.connection.readyState !== 1) {
-        await mongoose.connect(`${process.env.MONGODB_URI}/${this.dbName}`);
+        await mongoose.connect(process.env.MONGODB_URI!);
         console.log("Connected to MongoDB");
       }
     } catch (error: any) {


### PR DESCRIPTION
Was previously giving an error because params in the URI were not being parsed